### PR TITLE
Web UI: clipboard paste (Ctrl+V / right-click), Shift+Enter newline, view pills in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v0.6.8 (2026-06-04)
+
+### Bug Fixes
+
+- **Ctrl+V paste never reached the terminal** — xterm.js translates Ctrl+V keydown into the
+  raw `0x16` (SYN) control byte, cancels the browser event, and sends it to the PTY. TUI apps
+  like Claude Code then attempt to read the *server-side* clipboard (headless/empty), so the
+  browser clipboard was never pasted. The custom key handler now returns `false` for Ctrl+V —
+  xterm skips its keydown translation *without* `preventDefault`, letting the browser's native
+  paste event fire on xterm's hidden textarea and flow through the normal bracketed-paste path.
+  No clipboard API call in this path, so no double-paste and no permission prompt.
+
+- **Right-click now pastes the browser clipboard** — matches Windows terminal conventions
+  (PuTTY, Windows Terminal). Uses `navigator.clipboard.readText()` → `_term.paste()` since no
+  native paste event exists for right-click (one-time browser permission prompt).
+  Shift+right-click / Ctrl+right-click still open the browser context menu as escape hatches.
+
+- **Shift+Enter inserts a newline instead of submitting** — xterm.js sends CR for Enter
+  regardless of Shift. Shift+Enter is now intercepted and sent as LF (`0x0a`, same as Ctrl+J),
+  which TUI apps like Claude Code treat as "insert newline" vs CR "submit". Plain shells treat
+  LF and CR identically, so behaviour elsewhere is unchanged.
+
+### Features
+
+- **View pills in the header** — one pill per view (All Sessions, user views, and Hidden when
+  non-empty) rendered across the overview header, each with a live session count; a single
+  click activates the view. The dropdown button remains as the management menu, now labelled
+  "Views" on desktop. Below 600px the pills collapse and the dropdown trigger reverts to
+  showing the active view name, functioning as the compact switcher exactly as before. Pills
+  refresh each poll cycle with a string-compare guard to avoid needless innerHTML churn.
+
 ## v0.6.4 (2026-05-17)
 
 ### Bug Fixes

--- a/muxplex/frontend/app.js
+++ b/muxplex/frontend/app.js
@@ -354,6 +354,7 @@ async function pollSessions() {
     _pollFailCount = 0;
     setConnectionStatus('ok');
     renderGrid(sessions);
+    renderViewPills();
     renderSidebar(sessions, _viewingSession, _viewingRemoteId);
     handleBellTransitions(prev, sessions);
     updateSessionPill(sessions);
@@ -1042,6 +1043,46 @@ function renderFilterBar(container, allSessions) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Render the header view pills — one pill per view (All Sessions, user views,
+ * and Hidden when non-empty). Single click on a pill activates that view.
+ * Hidden on narrow screens via CSS (.view-pills collapses < 600px); the
+ * "Views" dropdown trigger remains as the mobile switcher + management menu.
+ */
+function renderViewPills() {
+  var pills = $('view-pills');
+  if (!pills) return;
+
+  var views = (_serverSettings && _serverSettings.views) || [];
+  var html = '';
+
+  // — All Sessions (always first)
+  var allCount = visibleCount(_currentSessions, _serverSettings, 'all');
+  var allActive = _activeView === 'all' ? ' view-pill--active' : '';
+  html += '<button class="view-pill' + allActive + '" data-view="all" title="All Sessions">All Sessions <span class="view-pill__count">' + allCount + '</span></button>';
+
+  // — User views (same 7-view cap as the dropdown)
+  for (var i = 0; i < views.length && i < 7; i++) {
+    var v = views[i];
+    var vActive = _activeView === v.name ? ' view-pill--active' : '';
+    html += '<button class="view-pill' + vActive + '" data-view="' + escapeHtml(v.name) + '" title="' + escapeHtml(v.name) + '">' + escapeHtml(v.name) + ' <span class="view-pill__count">' + visibleCount(_currentSessions, _serverSettings, v.name) + '</span></button>';
+  }
+
+  // — Hidden: only when it has sessions (or is currently active)
+  var hiddenCount = visibleCount(_currentSessions, _serverSettings, 'hidden');
+  if (hiddenCount > 0 || _activeView === 'hidden') {
+    var hiddenActive = _activeView === 'hidden' ? ' view-pill--active' : '';
+    html += '<button class="view-pill' + hiddenActive + '" data-view="hidden" title="Hidden">Hidden <span class="view-pill__count">' + hiddenCount + '</span></button>';
+  }
+
+  // Skip the DOM write when nothing changed — this runs every poll cycle and
+  // replacing innerHTML each time would reset :hover/:active button state.
+  if (pills._lastHtml !== html) {
+    pills.innerHTML = html;
+    pills._lastHtml = html;
+  }
+}
+
+/**
  * Populate #view-dropdown-menu with the full view list and update the label.
  * Called on open and after a view switch.
  */
@@ -1086,7 +1127,8 @@ function renderViewDropdown() {
 
   menu.innerHTML = html;
 
-  // Update the label
+  // Update the (mobile) dynamic label — on desktop the trigger shows the
+  // static "Views" label and the pills indicate the active view instead.
   var label = $('view-dropdown-label');
   if (label) {
     if (_activeView === 'all') {
@@ -1097,6 +1139,9 @@ function renderViewDropdown() {
       label.textContent = _activeView;
     }
   }
+
+  // Keep the header pills in sync with the dropdown state
+  renderViewPills();
 }
 
 /**
@@ -4077,6 +4122,15 @@ function bindStaticEventListeners() {
 
   on($('back-btn'), 'click', closeSession);
 
+  // View pills — single click activates that view (delegated; pills re-render)
+  var viewPills = $('view-pills');
+  if (viewPills) {
+    viewPills.addEventListener('click', function(e) {
+      var pill = e.target.closest && e.target.closest('[data-view]');
+      if (pill) switchView(pill.dataset.view);
+    });
+  }
+
   // View dropdown — trigger opens/closes, delegated item clicks switch view
   var viewDropdownTrigger = $('view-dropdown-trigger');
   if (viewDropdownTrigger) on(viewDropdownTrigger, 'click', toggleViewDropdown);
@@ -4577,7 +4631,8 @@ if (typeof module !== 'undefined' && module.exports) {
     closeFlyoutMenu,
     // Filter bar
     renderFilterBar,
-    // View dropdown
+    // View pills + dropdown
+    renderViewPills,
     renderViewDropdown,
     toggleViewDropdown,
     closeViewDropdown,

--- a/muxplex/frontend/index.html
+++ b/muxplex/frontend/index.html
@@ -19,12 +19,16 @@
   <div id="view-overview" class="view view--active">
     <header class="app-header">
       <h1 class="app-wordmark"><img src="/wordmark-on-dark.svg" alt="muxplex" height="24" /></h1>
-      <div class="view-dropdown" id="view-dropdown">
-        <button id="view-dropdown-trigger" class="view-dropdown__trigger" aria-haspopup="true" aria-expanded="false" aria-controls="view-dropdown-menu">
-          <span id="view-dropdown-label">All Sessions</span>
-          <span class="view-dropdown__caret" aria-hidden="true">&#9662;</span>
-        </button>
-        <div id="view-dropdown-menu" class="view-dropdown__menu hidden" role="menu" aria-label="Switch view"></div>
+      <div class="header-views">
+        <nav id="view-pills" class="view-pills" aria-label="Views"></nav>
+        <div class="view-dropdown" id="view-dropdown">
+          <button id="view-dropdown-trigger" class="view-dropdown__trigger" aria-haspopup="true" aria-expanded="false" aria-controls="view-dropdown-menu">
+            <span class="view-dropdown__static-label" aria-hidden="true">Views</span>
+            <span id="view-dropdown-label" class="view-dropdown__dynamic-label">All Sessions</span>
+            <span class="view-dropdown__caret" aria-hidden="true">&#9662;</span>
+          </button>
+          <div id="view-dropdown-menu" class="view-dropdown__menu hidden" role="menu" aria-label="Switch view"></div>
+        </div>
       </div>
       <div class="header-actions">
         <button id="new-session-btn" class="header-btn" aria-label="New session">+</button>

--- a/muxplex/frontend/style.css
+++ b/muxplex/frontend/style.css
@@ -1612,11 +1612,89 @@ body {
    View dropdown — header view selector
    ============================================================ */
 
+/* Header views group — pills + Views dropdown, between wordmark and actions */
+.header-views {
+  flex: 1;
+  min-width: 0; /* allow shrinking inside the flex header */
+  display: flex;
+  align-items: center;
+  margin: 0 12px;
+}
+
+/* View pills — one per view, single click activates. Collapses < 600px. */
+.view-pills {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none; /* Firefox — hide scrollbar, row still scrolls */
+}
+
+.view-pills::-webkit-scrollbar {
+  display: none; /* Chrome/Safari — hide scrollbar */
+}
+
+.view-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  max-width: 180px;
+  overflow: hidden;
+  white-space: nowrap;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  font-size: 12px;
+  font-family: var(--font-ui);
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 3px 12px;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.view-pill:hover {
+  border-color: var(--accent);
+  color: var(--text);
+  background: var(--bg-surface);
+}
+
+.view-pill--active {
+  border-color: var(--accent);
+  background: var(--accent-dim);
+  color: var(--accent);
+}
+
+.view-pill__count {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.view-pill--active .view-pill__count {
+  color: var(--accent);
+}
+
 .view-dropdown {
   position: relative;
   display: flex;
   align-items: center;
   margin-left: 12px;
+}
+
+/* Trigger label: mobile shows the active view name (pills are hidden, the
+   dropdown is the switcher); desktop shows a fixed "Views" label (pills
+   indicate the active view, dropdown is for switching + management). */
+.view-dropdown__static-label { display: none; }
+
+@media (min-width: 600px) {
+  .view-dropdown__static-label { display: inline; }
+  .view-dropdown__dynamic-label { display: none; }
+}
+
+@media (max-width: 599px) {
+  .view-pills { display: none; }
+  .view-dropdown { margin-left: 0; }
 }
 
 .view-dropdown__trigger {

--- a/muxplex/frontend/terminal.js
+++ b/muxplex/frontend/terminal.js
@@ -32,7 +32,24 @@ function _encodePayload(typeChar, str) {
 
 // ─── Clipboard helpers ───────────────────────────────────────────────────────
 // Ctrl+Shift+C: copy terminal selection to system clipboard
-// Ctrl+Shift+V: handled natively by xterm.js (browser paste event → xterm → WebSocket)
+// Ctrl+V / Ctrl+Shift+V: native browser paste event → xterm → WebSocket
+//   (Ctrl+V needs the custom key handler to return false so xterm doesn't
+//   swallow it as raw 0x16 — see attachCustomKeyEventHandler in openTerminal)
+// Right-click: reads the browser clipboard via _pasteFromClipboard below
+
+// Paste the BROWSER clipboard into the terminal via the async clipboard API.
+// Used only where no native paste event exists (right-click). _term.paste()
+// routes through xterm's bracketed-paste support so multi-line pastes arrive
+// as one paste event. Returns true if the async clipboard API is available.
+function _pasteFromClipboard() {
+  if (!(navigator.clipboard && navigator.clipboard.readText)) return false;
+  navigator.clipboard.readText().then(function(text) {
+    if (text && _term) _term.paste(text);
+  }).catch(function() {
+    // Permission denied or empty clipboard — nothing to paste
+  });
+  return true;
+}
 
 function _copyToClipboard(text) {
   if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -389,6 +406,31 @@ function openTerminal(sessionName, remoteId, fontSize) {
       return false;  // prevent xterm from processing
     }
 
+    // Ctrl+V → paste (Windows convention). By default xterm translates this
+    // keydown into raw 0x16 (SYN) sent to the PTY *and* cancels the event, so
+    // the browser clipboard is never read (apps like Claude Code then try the
+    // server-side clipboard, which is headless/empty). Returning false here
+    // skips xterm's keydown processing WITHOUT preventDefault — the browser's
+    // native paste event then fires on xterm's hidden textarea and xterm
+    // pastes it through its normal bracketed-paste path. No clipboard API
+    // call, so no double-paste and no permission prompt (COE: custom paste
+    // handlers that read the clipboard caused double-paste).
+    if (e.ctrlKey && !e.shiftKey && !e.altKey && (e.key === 'v' || e.key === 'V')) {
+      return false;
+    }
+
+    // Shift+Enter → send LF (0x0a, same as Ctrl+J) instead of CR. TUI apps
+    // like Claude Code treat LF as "insert newline" vs CR "submit", matching
+    // Shift+Enter behavior in desktop terminals. Plain shells treat LF and CR
+    // identically, so this is harmless everywhere else.
+    if (e.shiftKey && !e.ctrlKey && !e.altKey && !e.metaKey && e.key === 'Enter') {
+      if (_ws && _ws.readyState === WebSocket.OPEN) {
+        _ws.send(_encodePayload(0x30, '\n'));
+      }
+      e.preventDefault();
+      return false;
+    }
+
     // Ctrl+F → open search bar
     if (e.ctrlKey && !e.shiftKey && (e.key === 'f' || e.key === 'F' || e.code === 'KeyF')) {
       _openSearch();
@@ -490,13 +532,15 @@ function openTerminal(sessionName, remoteId, fontSize) {
     newPrev.addEventListener('click', _searchPrev);
   }
 
-  // --- Right-click context menu ---
-  // Suppress the browser context menu on plain right-click inside the terminal
-  // so tmux's own menu (when `set -g mouse on`) isn't covered by the browser's.
-  // Shift+RMB and Ctrl+RMB still open the browser context menu as escape hatches.
+  // --- Right-click → paste ---
+  // Plain right-click pastes the browser clipboard (Windows terminal convention:
+  // PuTTY, Windows Terminal). The browser context menu is suppressed so it
+  // doesn't cover the terminal; Shift+RMB and Ctrl+RMB still open the browser
+  // context menu as escape hatches.
   container.addEventListener('contextmenu', function(e) {
     if (e.shiftKey || e.ctrlKey || e.metaKey) return; // let modified clicks through
     e.preventDefault();
+    _pasteFromClipboard();
   });
 
   connectWebSocket(sessionName, remoteId);

--- a/muxplex/frontend/tests/test_terminal.mjs
+++ b/muxplex/frontend/tests/test_terminal.mjs
@@ -993,22 +993,70 @@ test('terminal.js loads xterm-addon-image for inline graphics', () => {
   assert.ok(source.includes('ImageAddon'), 'must reference ImageAddon');
 });
 
-// --- Ctrl+Shift+V: xterm.js handles paste natively, no custom interception ---
+// --- Paste: Ctrl+V defers to native browser paste; no clipboard read in keydown ---
 
-test('terminal.js does NOT intercept Ctrl+Shift+V in attachCustomKeyEventHandler', () => {
-  // COE review: every custom paste handler we built caused either double-paste or encoding issues.
-  // On Linux, Ctrl+Shift+V is a native browser paste shortcut — it fires a paste event on the
-  // focused textarea, xterm.js catches it natively. On macOS, Cmd+V does the same.
-  // Zero custom paste code needed.
+test('terminal.js Ctrl+V branch returns false WITHOUT reading the clipboard (native paste, no double-paste)', () => {
+  // COE review: every custom paste handler that READ the clipboard caused either
+  // double-paste or encoding issues. The fix: the Ctrl+V branch only returns false
+  // (skips xterm's 0x16 translation + event cancel) and must NOT call the clipboard
+  // API or preventDefault — the browser's native paste event then fires on xterm's
+  // hidden textarea and xterm pastes it via its normal bracketed-paste path.
+  // Ctrl+Shift+V (Linux) and Cmd+V (macOS) already work natively and stay untouched.
   const source = fs.readFileSync(new URL('../terminal.js', import.meta.url), 'utf8');
   const handlerStart = source.indexOf('attachCustomKeyEventHandler');
   const handlerEnd = source.indexOf('onSelectionChange', handlerStart);
   const handlerBlock = source.substring(handlerStart, handlerEnd);
-  // Must NOT have any V key interception
-  assert.ok(!handlerBlock.includes("e.key === 'V'"),
+
+  // Ctrl+V must be intercepted (so xterm doesn't swallow it as raw 0x16/SYN)...
+  const vBranch = handlerBlock.match(/if \(e\.ctrlKey && !e\.shiftKey[^)]*\(e\.key === 'v'[^{]*\{([^}]*)\}/);
+  assert.ok(vBranch, 'must have a Ctrl+V (no shift) branch in the custom key handler');
+  // ...but the branch must ONLY return false — no clipboard read, no preventDefault
+  assert.ok(!vBranch[1].includes('clipboard') && !vBranch[1].includes('_pasteFromClipboard'),
+    'Ctrl+V branch must NOT read the clipboard — native paste event handles it (double-paste otherwise)');
+  assert.ok(!vBranch[1].includes('preventDefault'),
+    'Ctrl+V branch must NOT preventDefault — that would suppress the native paste event');
+  assert.ok(vBranch[1].includes('return false'),
+    'Ctrl+V branch must return false so xterm skips its 0x16 keydown translation');
+
+  // Ctrl+Shift+V must NOT be intercepted — every V-key check excludes shift
+  assert.ok(!/e\.ctrlKey && e\.shiftKey[^)]*Key[Vv]/.test(handlerBlock) &&
+            !/e\.ctrlKey && e\.shiftKey[^)]*'[Vv]'/.test(handlerBlock),
     'must NOT intercept Ctrl+Shift+V — xterm.js handles paste natively via browser events');
-  assert.ok(!handlerBlock.includes("e.code === 'KeyV'"),
-    'must NOT intercept KeyV — xterm.js handles paste natively via browser events');
+});
+
+// --- Right-click pastes browser clipboard (Windows terminal convention) ---
+
+test('terminal.js right-click pastes from the browser clipboard', () => {
+  const source = fs.readFileSync(new URL('../terminal.js', import.meta.url), 'utf8');
+  assert.ok(source.includes('_pasteFromClipboard'),
+    'must define _pasteFromClipboard for the right-click path');
+  assert.ok(source.includes('navigator.clipboard.readText'),
+    '_pasteFromClipboard must use navigator.clipboard.readText (no native paste event on right-click)');
+  assert.ok(source.includes('_term.paste('),
+    'must paste via _term.paste() so multi-line pastes use bracketed paste');
+  const ctxStart = source.indexOf("addEventListener('contextmenu'");
+  assert.ok(ctxStart !== -1, 'must have a contextmenu handler');
+  const ctxBlock = source.substring(ctxStart, source.indexOf('});', ctxStart));
+  assert.ok(ctxBlock.includes('_pasteFromClipboard()'),
+    'plain right-click must paste the clipboard');
+  assert.ok(ctxBlock.includes('e.shiftKey || e.ctrlKey'),
+    'modified right-clicks must still open the browser context menu');
+});
+
+// --- Shift+Enter inserts a newline (LF) instead of submitting (CR) ---
+
+test('terminal.js Shift+Enter sends LF (0x0a) so TUI apps insert a newline', () => {
+  // TUI apps like Claude Code treat LF (Ctrl+J) as "insert newline" vs CR "submit".
+  // xterm.js sends CR for Enter regardless of shift, so Shift+Enter must be
+  // intercepted and sent as '\n' over the WebSocket (ttyd input frame 0x30).
+  const source = fs.readFileSync(new URL('../terminal.js', import.meta.url), 'utf8');
+  const handlerStart = source.indexOf('attachCustomKeyEventHandler');
+  const handlerEnd = source.indexOf('onSelectionChange', handlerStart);
+  const handlerBlock = source.substring(handlerStart, handlerEnd);
+  const enterBranch = handlerBlock.match(/if \(e\.shiftKey[^)]*e\.key === 'Enter'\) \{([\s\S]*?)return false;/);
+  assert.ok(enterBranch, 'must have a Shift+Enter branch in the custom key handler');
+  assert.ok(enterBranch[1].includes("_encodePayload(0x30, '\\n')"),
+    'Shift+Enter must send LF as a ttyd input frame (0x30)');
 });
 
 // --- UTF-8 output decoding via TextDecoder ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "muxplex"
-version = "0.6.7"
+version = "0.6.8"
 description = "Web-based tmux session dashboard — access all your tmux sessions from any browser"
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 
 [[package]]
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "muxplex"
-version = "0.6.0"
+version = "0.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Three web-UI improvements, primarily for Windows browser users:

### 1. Clipboard paste actually works (Ctrl+V and right-click)

**Root cause:** xterm.js translates Ctrl+V keydown into the raw `0x16` (SYN) control byte, cancels the browser event, and sends it to the PTY. TUI apps like Claude Code respond by trying to read the *server-side* clipboard (headless/empty) — the browser clipboard was never read, so nothing pasted.

**Fix:**
- **Ctrl+V** — the custom key handler returns `false` so xterm skips its `0x16` translation *without* `preventDefault`; the browser's native paste event then fires on xterm's hidden textarea and flows through the normal bracketed-paste path. Deliberately no clipboard-API call in the keydown path (the prior COE: clipboard-reading paste handlers caused double-paste).
- **Right-click** — pastes via `navigator.clipboard.readText()` → `_term.paste()` (Windows terminal convention; no native paste event exists for right-click). One-time browser permission prompt. Shift/Ctrl+right-click still open the browser context menu.
- Ctrl+Shift+V (Linux) / Cmd+V (macOS) untouched — already worked natively.

### 2. Shift+Enter inserts a newline

xterm.js sends CR for Enter regardless of Shift. Shift+Enter is now intercepted and sent as LF (`0x0a`, same as Ctrl+J), which TUI apps like Claude Code treat as "insert newline" vs CR "submit". Plain shells treat LF and CR identically, so behaviour elsewhere is unchanged.

### 3. View pills across the overview header

- One pill per view (All Sessions, user views, Hidden when non-empty) with live session counts; single click activates the view.
- The dropdown button remains as the management menu, relabelled to a fixed "Views" on desktop.
- **< 600px:** pills collapse and the dropdown trigger reverts to showing the active view name — the compact switcher works exactly as before.
- Pills refresh each poll cycle with a string-compare guard (no innerHTML churn / hover-state reset).

### Housekeeping

- Version bumped to **0.6.8** — also rotates the `?v=` asset cache-buster so browsers that cached 0.6.7 assets fetch the new frontend files.
- CHANGELOG entry added.

## Tests

- `pytest -m "not integration"`: **1301 passed**
- `test_app.mjs`: **404/404 pass**
- `test_terminal.mjs`: updated the Ctrl+Shift+V regression test to the new paste contract (return-false-only, no clipboard read, no preventDefault) and added tests for right-click paste and Shift+Enter LF — all pass. The 27 pre-existing harness failures in this suite are unchanged (verified identical failure set against a clean baseline).

## Manual verification

Tested live against a local serve on Windows/Chrome: Ctrl+V pastes (single paste, multi-line arrives bracketed), right-click pastes after the one-time clipboard permission prompt, Shift+Enter inserts a newline in Claude Code, pills render/activate/collapse responsively.

